### PR TITLE
feat(log): add support for file logging using lumberjack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,5 +64,6 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/log/log.go
+++ b/log/log.go
@@ -90,7 +90,7 @@ func Init(cfg Config) Interface {
 		switch cfg.Output {
 		case OutputFile:
 			if cfg.LumberjackConfig.Filename == "" {
-				log.Panic("filename cannot be empty")
+				log.Fatal("filename cannot be empty")
 			}
 
 			logFile := lumberjack.Logger{

--- a/log/log.go
+++ b/log/log.go
@@ -38,7 +38,8 @@ const (
 	LevelFatal = slog.Level(10)
 	LevelPanic = slog.Level(12)
 
-	OutputFile = "file"
+	OutputFile         = "file"
+	OutputFileNConsole = "both"
 )
 
 type Interface interface {
@@ -105,6 +106,20 @@ func Init(cfg Config) Interface {
 			}
 
 			writer = &logFile
+		case OutputFileNConsole:
+			if cfg.LumberjackConfig.Filename == "" {
+				log.Fatal("filename cannot be empty")
+			}
+
+			logFile := lumberjack.Logger{
+				Filename:   cfg.LumberjackConfig.Filename,
+				MaxSize:    cfg.LumberjackConfig.MaxSize,
+				MaxBackups: cfg.LumberjackConfig.MaxBackups,
+				MaxAge:     cfg.LumberjackConfig.MaxAge,
+				Compress:   cfg.LumberjackConfig.Compress,
+			}
+
+			writer = io.MultiWriter(&logFile, os.Stdout)
 		default:
 			writer = os.Stdout
 		}


### PR DESCRIPTION
## Log Changes

- Added support for file-based logging using `lumberjack`
- Introduced new `Output` field in `log.Config` to choose between `stdout` or `file`
- Added `LumberjackConfig` to configure file path, rotation size, backup count, etc.
- Updated `Init()` logic to handle file logging based on config.Output

## Type Of Change

- [x] new features
- [ ] bugfix
- [ ] code improvements
- [ ] hotfix
- [ ] breaking changes

## User Test Result
```
log := log.Init(log.Config{
		Level:  "debug",
		Output: []string{"file", "console"},
		LumberjackConfig: log.LumbejackConfig{
			Filename:   "./logs/app.log",
			MaxSize:    10,
			MaxBackups: 3,
			MaxAge:     30,
			Compress:   true,
		},
	})

log.Debug(context.Background(), "success to create log in console and file")
```
#### 🖥️ Log on Console

<img width="1203" alt="Log on Console" src="https://github.com/user-attachments/assets/1fc9f623-d678-4cd5-879a-fc9dc303a41b" />

---

#### 📁 New Folder and File Created

<img width="333" alt="Log File Created" src="https://github.com/user-attachments/assets/41d36bfb-7e96-40f7-8030-669372f4aee5" />

---

#### 📝 Log on File

<img width="1137" alt="Log on File" src="https://github.com/user-attachments/assets/4e4cfe6a-952b-4c1a-96c4-94c05c5e287c" />

---